### PR TITLE
feat: remove num_contexts limitation, enable dynamic context processing

### DIFF
--- a/test_retrieval.py
+++ b/test_retrieval.py
@@ -243,7 +243,7 @@ def main():
     
     # Tạo dataset và dataloader
     max_seq_len = config.get('max_seq_len', 512)
-    dataset = RetrievalDataset(test_data, model.tokenizer, max_len=max_seq_len, num_contexts=5)
+    dataset = RetrievalDataset(test_data, model.tokenizer, max_len=max_seq_len)  # 🆕 Bỏ num_contexts
     
     dataloader = DataLoader(
         dataset,

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -65,25 +65,18 @@ class DatasetLoader:
         
         for item in data:
             if 'question' in item and 'context' in item:
-                # Xử lý context từ format HotpotQA
-                contexts = []
-                for title, sentences in item['context']:
-                    # Ghép các câu thành đoạn văn
-                    paragraph = ' '.join(sentences)
-                    contexts.append({
-                        'title': title,
-                        'text': paragraph
-                    })
+                # 🚀 GIỮ NGUYÊN format HotpotQA gốc: [title, [sentences]]
+                # Không convert thành {'title': str, 'text': str}
+                contexts = item['context']  # Giữ nguyên [[title, [sentences]], ...]
                 
                 processed_item = {
                     'id': item.get('_id', f"hotpot_{len(processed_data)}"),
                     'question': item['question'],
                     'answer': item.get('answer', ''),
-                    'contexts': contexts,
+                    'contexts': contexts,  # Format gốc: [[title, [sentences]], ...]
                     'type': item.get('type', 'bridge'),
                     'level': item.get('level', 'medium'),
                     'dataset': 'hotpotqa',
-                    # Preserve original fields including supporting_facts
                     'supporting_facts': item.get('supporting_facts', []),
                     'original': item  # Keep full original data for reference
                 }


### PR DESCRIPTION
- Remove num_contexts parameter from RetrievalDataset
- Enable processing of all available contexts per sample
- Simplify paragraph processing: 1 context = 1 paragraph
- Update test_retrieval.py to use dynamic contexts
- Fix data_loader.py to preserve HotpotQA format [[title, [sentences]], ...]
- Improve evaluation flexibility and data utilization